### PR TITLE
Move custom date from hass.data to ConfigEntry

### DIFF
--- a/custom_components/monitormysolar/__init__.py
+++ b/custom_components/monitormysolar/__init__.py
@@ -111,8 +111,6 @@ async def async_unload_entry(hass, entry: MonitorMySolarEntry):
             Platform.BUTTON,
             Platform.UPDATE,
         ])
-        if unload_ok:
-            hass.data.pop(DOMAIN)
         return unload_ok
     except Exception as e:
         _LOGGER.error(f"Error during unload: {e}")
@@ -131,16 +129,17 @@ async def setup_entities(hass, entry: MonitorMySolarEntry, inverter_brand, dongl
         Platform.UPDATE,
     ]
 
-    for platform in platforms:
-        try:
-            _LOGGER.info(f"Setting up {platform} entities for {inverter_brand}")
-            if not hass.data.get(f"{DOMAIN}_setup_done_{platform}", False):
-                await hass.config_entries.async_forward_entry_setups(entry, [platform])
-                hass.data[f"{DOMAIN}_setup_done_{platform}"] = True
-            _LOGGER.info(f"Successfully set up {platform} entities for {inverter_brand}")
-        except Exception as e:
-            _LOGGER.error(f"Error setting up {platform} entities: {e}")
-            return False  # Return False if there's an error in setting up a platform
+    # for platform in platforms:
+    #     try:
+    #         _LOGGER.info(f"Setting up {platform} entities for {inverter_brand}")
+    #         if not hass.data.get(f"{DOMAIN}_setup_done_{platform}", False):
+    #             await hass.config_entries.async_forward_entry_setups(entry, [platform])
+    #             hass.data[f"{DOMAIN}_setup_done_{platform}"] = True
+    #         _LOGGER.info(f"Successfully set up {platform} entities for {inverter_brand}")
+    #     except Exception as e:
+    #         _LOGGER.error(f"Error setting up {platform} entities: {e}")
+    #         return False  # Return False if there's an error in setting up a platform
+    await hass.config_entries.async_forward_entry_setups(entry, platforms)
     return True  # Return True if all platforms are set up successfully
 
 

--- a/custom_components/monitormysolar/__init__.py
+++ b/custom_components/monitormysolar/__init__.py
@@ -7,11 +7,9 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.components import mqtt
 from .const import DOMAIN, ENTITIES
 from .mqttHandeler import MQTTHandler
-from .coordinator import MonitorMySolar
+from .coordinator import MonitorMySolar, MonitorMySolarEntry
 
 _LOGGER = logging.getLogger(__name__)
-
-type MonitorMySolarEntry = ConfigEntry[MonitorMySolar]
 
 async def async_setup_entry(hass: HomeAssistant, entry: MonitorMySolarEntry):
     try:
@@ -26,6 +24,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MonitorMySolarEntry):
 
         # Initialize the MQTT handler and store it in the hass data under the domain
         mqtt_handler = MQTTHandler(hass)
+        coordinator.mqtt_handler = mqtt_handler
         # hass.data.setdefault(DOMAIN, {})["mqtt_handler"] = mqtt_handler
 
         entry.runtime_data = coordinator

--- a/custom_components/monitormysolar/binary_sensor.py
+++ b/custom_components/monitormysolar/binary_sensor.py
@@ -86,10 +86,7 @@ class BatteryStatusBinarySensor(BinarySensorEntity):
 
     async def async_added_to_hass(self):
         """Subscribe to events when added to hass."""
-        self.hass.bus.async_listen(f"{DOMAIN}_sensor_updated", self._handle_event)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_sensor_updated", self._handle_event)
+        )
         _LOGGER.debug(f"Binary sensor {self.entity_id} subscribed to event")
-
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Binary sensor {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_sensor_updated", self._handle_event)

--- a/custom_components/monitormysolar/button.py
+++ b/custom_components/monitormysolar/button.py
@@ -105,7 +105,7 @@ class FirmwareUpdateButton(ButtonEntity):
     async def async_will_remove_from_hass(self):
         """Unsubscribe from events when removed."""
         _LOGGER.debug(f"Button {self.entity_id} will be removed from hass")
-        self.hass.bus.async_remove_listener(f"{DOMAIN}_button_updated", self._handle_event)
+        self.hass.bus._async_remove_listener(f"{DOMAIN}_button_updated", self._handle_event)
 
 
 class RestartButton(ButtonEntity):
@@ -152,4 +152,4 @@ class RestartButton(ButtonEntity):
     async def async_will_remove_from_hass(self):
         """Unsubscribe from events when removed."""
         _LOGGER.debug(f"Button {self.entity_id} will be removed from hass")
-        self.hass.bus.async_remove_listener(f"{DOMAIN}_button_updated", self._handle_event)
+        self.hass.bus._async_remove_listener(f"{DOMAIN}_button_updated", self._handle_event)

--- a/custom_components/monitormysolar/button.py
+++ b/custom_components/monitormysolar/button.py
@@ -3,20 +3,25 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.components.mqtt import async_publish
 from homeassistant.core import callback
 from .const import DOMAIN, ENTITIES, FIRMWARE_CODES
+from .coordinator import MonitorMySolar
+from . import MonitorMySolarEntry
 
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(hass, entry: MonitorMySolarEntry, async_add_entities):
     inverter_brand = entry.data.get("inverter_brand")
     dongle_id = entry.data.get("dongle_id").lower().replace("-", "_")
     firmware_code = entry.data.get("firmware_code")
     device_type = FIRMWARE_CODES.get(firmware_code, {}).get("Device_Type", "")
     entity_info = entry.data.get("entity_info", {})
 
+    coordinator = entry.runtime_data
+
     brand_entities = ENTITIES.get(inverter_brand, {})
     buttons_config = brand_entities.get("button", {})
 
-    mqtt_handler = hass.data[DOMAIN]["mqtt_handler"]
+    mqtt_handler = coordinator.mqtt_handler
+    # mqtt_handler = hass.data[DOMAIN]["mqtt_handler"]
 
     entities = []
     for bank_name, buttons in buttons_config.items():
@@ -37,7 +42,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     async_add_entities(entities, True)
 class FirmwareUpdateButton(ButtonEntity):
-    def __init__(self, button_info, hass, entry, dongle_id, bank_name, mqtt_handler):
+    def __init__(self, button_info, hass, entry: MonitorMySolarEntry, dongle_id, bank_name, mqtt_handler):
         """Initialize the button."""
         _LOGGER.debug(f"Initializing button with info: {button_info}")
         self.button_info = button_info
@@ -51,6 +56,7 @@ class FirmwareUpdateButton(ButtonEntity):
         self.hass = hass
         self._manufacturer = entry.data.get("inverter_brand")
         self._mqtt_handler = mqtt_handler
+        self.coordinator = entry.runtime_data
 
     @property
     def name(self):
@@ -88,7 +94,7 @@ class FirmwareUpdateButton(ButtonEntity):
         if sw_version < latest_firmware_version:
             # Firmware update is needed
             _LOGGER.info(f"Firmware update button pressed for {formatted_dongle_id}")
-            await self.hass.data[DOMAIN]["mqtt_handler"].send_update(self._dongle_id, "firmware_update", "updatedongle", self)
+            await self.coordinator.mqtt_handler.send_update(self._dongle_id, "firmware_update", "updatedongle", self)
         else:
             # No update needed
             _LOGGER.info(f"No firmware update needed for {formatted_dongle_id}. SW_VERSION: {sw_version}, LatestFirmwareVersion: {latest_firmware_version}")
@@ -136,7 +142,7 @@ class RestartButton(ButtonEntity):
     async def async_press(self):
 
         value = "1"
-        await self.hass.data[DOMAIN]["mqtt_handler"].send_update(
+        await self.coordinator.mqtt_handler.send_update(
                 self._dongle_id.replace("_", "-"),
                 self._button_type["unique_id"],
                 value,

--- a/custom_components/monitormysolar/button.py
+++ b/custom_components/monitormysolar/button.py
@@ -102,11 +102,6 @@ class FirmwareUpdateButton(ButtonEntity):
                 "title": "Firmware Update",
                 "message": "No update available for the dongle."
             })
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Button {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_button_updated", self._handle_event)
-
 
 class RestartButton(ButtonEntity):
     def __init__(self, button_info, hass, entry, dongle_id, bank_name, mqtt_handler):
@@ -148,8 +143,3 @@ class RestartButton(ButtonEntity):
                 value,
                 self,
             )
-
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Button {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_button_updated", self._handle_event)

--- a/custom_components/monitormysolar/coordinator.py
+++ b/custom_components/monitormysolar/coordinator.py
@@ -1,0 +1,14 @@
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from .mqttHandeler import MQTTHandler
+
+class MonitorMySolar:
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize the Coordinator."""
+        self.hass = hass
+        self._entry = entry
+        self.mqtt_handler: MQTTHandler = {}
+        self.firmware_code: str = ""
+        self.current_fw_version: str = ""
+        self.current_ui_version: str = ""
+        self.server_versions = {}

--- a/custom_components/monitormysolar/coordinator.py
+++ b/custom_components/monitormysolar/coordinator.py
@@ -1,14 +1,15 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from .mqttHandeler import MQTTHandler
 
 class MonitorMySolar:
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize the Coordinator."""
         self.hass = hass
         self._entry = entry
-        self.mqtt_handler: MQTTHandler = {}
+        self.mqtt_handler: {}
         self.firmware_code: str = ""
         self.current_fw_version: str = ""
         self.current_ui_version: str = ""
         self.server_versions = {}
+
+type MonitorMySolarEntry = ConfigEntry[MonitorMySolar]

--- a/custom_components/monitormysolar/mqttHandeler.py
+++ b/custom_components/monitormysolar/mqttHandeler.py
@@ -5,6 +5,7 @@ import json
 from homeassistant.core import HomeAssistant
 from homeassistant.components.mqtt import async_publish
 from homeassistant.components import mqtt
+from . import MonitorMySolarEntry
 
 from .const import DOMAIN
 
@@ -20,8 +21,10 @@ class MQTTHandler:
         self.current_entity = None  # Store the current entity
         self._unsubscribe_response = None
 
-    async def async_setup(self, entry):
-        self.hass.data[DOMAIN]["mqtt_handler"] = self
+    async def async_setup(self, entry: MonitorMySolarEntry):
+        coordinator = entry.runtime_data
+        coordinator.mqtt_handler = self
+        entry.runtime_data = coordinator
 
     async def send_update(self, dongle_id, unique_id, value, entity):
         now = datetime.now()

--- a/custom_components/monitormysolar/mqttHandeler.py
+++ b/custom_components/monitormysolar/mqttHandeler.py
@@ -5,7 +5,7 @@ import json
 from homeassistant.core import HomeAssistant
 from homeassistant.components.mqtt import async_publish
 from homeassistant.components import mqtt
-from . import MonitorMySolarEntry
+from .coordinator import MonitorMySolarEntry
 
 from .const import DOMAIN
 

--- a/custom_components/monitormysolar/number.py
+++ b/custom_components/monitormysolar/number.py
@@ -3,6 +3,7 @@ from homeassistant.components.number import NumberEntity
 from homeassistant.core import callback
 import json
 from .const import DOMAIN, ENTITIES
+from . import MonitorMySolarEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(entities, True)
 
 class InverterNumber(NumberEntity):
-    def __init__(self, entity_info, hass, entry, dongle_id, bank_name):
+    def __init__(self, entity_info, hass, entry: MonitorMySolarEntry, dongle_id, bank_name):
         """Initialize the number."""
         self.entity_info = entity_info
         self._attr_name = entity_info["name"]
@@ -49,11 +50,12 @@ class InverterNumber(NumberEntity):
             "name": f"Inverter {self._dongle_id}",
             "manufacturer": f"{self._manufacturer}",
         }
+        self.coordinator = entry.runtime_data
 
     async def async_set_native_value(self, value):
         """Set the number value."""
         _LOGGER.debug(f"Setting value of number {self.entity_id} to {value}")
-        mqtt_handler = self.hass.data[DOMAIN].get("mqtt_handler")
+        mqtt_handler = self.coordinator.mqtt_handler
         if mqtt_handler is not None:
             # Save the current value before changing
             self._previous_value = self._attr_native_value

--- a/custom_components/monitormysolar/number.py
+++ b/custom_components/monitormysolar/number.py
@@ -92,12 +92,7 @@ class InverterNumber(NumberEntity):
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
         #_LOGGER.debug(f"Number {self.entity_id} added to hass")
-        self.hass.bus.async_listen(f"{DOMAIN}_number_updated", self._handle_event)
-       # _LOGGER.debug(f"Number {self.entity_id} subscribed to event")
-
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-       # _LOGGER.debug(f"Number {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(
-            f"{DOMAIN}_number_updated", self._handle_event
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_number_updated", self._handle_event)
         )
+       # _LOGGER.debug(f"Number {self.entity_id} subscribed to event")

--- a/custom_components/monitormysolar/select.py
+++ b/custom_components/monitormysolar/select.py
@@ -106,15 +106,13 @@ class InverterSelect(SelectEntity):
                 _LOGGER.debug(f"Select {self.entity_id} state updated to {self._state}")
                 # Schedule state update on the main thread
                 self.hass.loop.call_soon_threadsafe(self.async_write_ha_state)
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Select {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_select_updated", self._handle_event)
 
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
        # _LOGGER.debug(f"Select {self.entity_id} added to hass")
-        self.hass.bus.async_listen(f"{DOMAIN}_select_updated", self._handle_event)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_select_updated", self._handle_event)
+        )
         #_LOGGER.debug(f"Select {self.entity_id} subscribed to event")
 
 
@@ -173,8 +171,6 @@ class QuickChargeDurationSelect(SelectEntity):
 
     async def async_added_to_hass(self):
         """Subscribe to events when added to hass."""
-        self.hass.bus.async_listen(f"{DOMAIN}_select_updated", self._handle_event)
-
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_select_updated", self._handle_event)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_select_updated", self._handle_event)
+        )

--- a/custom_components/monitormysolar/sensor.py
+++ b/custom_components/monitormysolar/sensor.py
@@ -154,15 +154,12 @@ class InverterSensor(SensorEntity):
                 _LOGGER.debug(f"Sensor {self.entity_id} state updated to {self._state}")
                 self.async_write_ha_state()
 
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Sensor {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_sensor_updated", self._handle_event)
-
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
         _LOGGER.debug(f"Sensor {self.entity_id} added to hass")
-        self.hass.bus.async_listen(f"{DOMAIN}_sensor_updated", self._handle_event)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_sensor_updated", self._handle_event)
+        )
         _LOGGER.debug(f"Sensor {self.entity_id} subscribed to event")
 
 
@@ -243,15 +240,12 @@ class StatusSensor(SensorEntity):
 
                 self.async_write_ha_state()
 
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Sensor {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_uptime_sensor_updated", self._handle_event)
-
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
         _LOGGER.debug(f"Sensor {self.entity_id} added to hass")
-        self.hass.bus.async_listen(f"{DOMAIN}_uptime_sensor_updated", self._handle_event)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_uptime_sensor_updated", self._handle_event)
+        )
         _LOGGER.debug(f"Sensor {self.entity_id} subscribed to event")
 
 
@@ -337,13 +331,10 @@ class PowerFlowSensor(SensorEntity):
 
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
-        self.hass.bus.async_listen(f"{DOMAIN}_sensor_updated", self._handle_event)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_sensor_updated", self._handle_event)
+        )
         _LOGGER.debug(f"Sensor {self.entity_id} subscribed to event")
-
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Sensor {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_sensor_updated", self._handle_event)
 
 
 
@@ -412,15 +403,12 @@ class CombinedSensor(SensorEntity):
             self._state = sum(self._sensor_values.values())
             self.async_write_ha_state()
 
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Sensor {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_sensor_updated", self._handle_event)
-
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
         _LOGGER.debug(f"Sensor {self.entity_id} added to hass")
-        self.hass.bus.async_listen(f"{DOMAIN}_sensor_updated", self._handle_event)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_sensor_updated", self._handle_event)
+        )
         _LOGGER.debug(f"Sensor {self.entity_id} subscribed to event")
 
 class BankUpdateSensor(SensorEntity):
@@ -484,15 +472,12 @@ class BankUpdateSensor(SensorEntity):
                 self._state = current_time  # Update state to most recent update
                 self.async_write_ha_state()
 
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Unsubscribing from bank update event for {self.entity_id}")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_bank_updated", self._handle_bank_update)
-
     async def async_added_to_hass(self):
         """Subscribe to events when added to hass."""
         _LOGGER.debug(f"Subscribing to bank update event for {self.entity_id}")
-        self.hass.bus.async_listen(f"{DOMAIN}_bank_updated", self._handle_bank_update)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_bank_updated", self._handle_bank_update)
+        )
 
 class FaultWarningSensor(SensorEntity):
     def __init__(self, sensor_info, hass, entry, dongle_id, bank_name):
@@ -587,14 +572,12 @@ class FaultWarningSensor(SensorEntity):
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
         _LOGGER.debug(f"Sensor {self.entity_id} added to hass")
-        self.hass.bus.async_listen(f"{DOMAIN}_warning_updated", self._handle_event)
-        self.hass.bus.async_listen(f"{DOMAIN}_fault_updated", self._handle_event)
-
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Sensor {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_warning_updated", self._handle_event)
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_fault_updated", self._handle_event)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_warning_updated", self._handle_event)
+        )
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_fault_updated", self._handle_event)
+        )
 
 class CalculatedSensor(SensorEntity):
     def __init__(self, sensor_info, hass, entry, dongle_id, bank_name):
@@ -736,11 +719,9 @@ class CalculatedSensor(SensorEntity):
 
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
-        self.hass.bus.async_listen(f"{DOMAIN}_sensor_updated", self._handle_event)
-
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_sensor_updated", self._handle_event)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_sensor_updated", self._handle_event)
+        )
 
 class TemperatureSensor(SensorEntity):
     def __init__(self, sensor_info, hass, entry, dongle_id, bank_name):
@@ -828,13 +809,10 @@ class TemperatureSensor(SensorEntity):
                 _LOGGER.debug(f"Sensor {self.entity_id} state updated to {self._state}")
                 self.async_write_ha_state()
 
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Sensor {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_sensor_updated", self._handle_event)
-
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
         _LOGGER.debug(f"Sensor {self.entity_id} added to hass")
-        self.hass.bus.async_listen(f"{DOMAIN}_sensor_updated", self._handle_event)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_sensor_updated", self._handle_event)
+        )
         _LOGGER.debug(f"Sensor {self.entity_id} subscribed to event")

--- a/custom_components/monitormysolar/switch.py
+++ b/custom_components/monitormysolar/switch.py
@@ -2,6 +2,7 @@ import logging
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
 from .const import DOMAIN, ENTITIES, FIRMWARE_CODES
+from . import MonitorMySolarEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(entities, True)
 
 class InverterSwitch(SwitchEntity):
-    def __init__(self, entity_info, hass, entry, dongle_id, bank_name):
+    def __init__(self, entity_info, hass, entry: MonitorMySolarEntry, dongle_id, bank_name):
         """Initialize the switch."""
         _LOGGER.debug(f"Initializing switch with info: {entity_info}")
         self.entity_info = entity_info
@@ -43,6 +44,7 @@ class InverterSwitch(SwitchEntity):
         self.hass = hass
         self._manufacturer = entry.data.get("inverter_brand")
         self._previous_state = None
+        self.coordinator = entry.runtime_data
 
     @property
     def name(self):
@@ -66,7 +68,7 @@ class InverterSwitch(SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
-        mqtt_handler = self.hass.data[DOMAIN].get("mqtt_handler")
+        mqtt_handler = self.coordinator.mqtt_handler
         if mqtt_handler is not None:
             self._previous_state = self._state
             self._state = True  # Optimistically update the state
@@ -82,7 +84,7 @@ class InverterSwitch(SwitchEntity):
 
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
-        mqtt_handler = self.hass.data[DOMAIN].get("mqtt_handler")
+        mqtt_handler = self.coordinator.mqtt_handler
         if mqtt_handler is not None:
             self._previous_state = self._state  # Save the current state before changing
             self._state = False  # Optimistically update the state in HA

--- a/custom_components/monitormysolar/switch.py
+++ b/custom_components/monitormysolar/switch.py
@@ -118,13 +118,10 @@ class InverterSwitch(SwitchEntity):
                 # Schedule state update on the main thread
                 self.hass.loop.call_soon_threadsafe(self.async_write_ha_state)
 
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Switch {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_switch_updated", self._handle_event)
-
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
         _LOGGER.debug(f"Switch {self.entity_id} added to hass")
-        self.hass.bus.async_listen(f"{DOMAIN}_switch_updated", self._handle_event)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_switch_updated", self._handle_event)
+        )
         _LOGGER.debug(f"Switch {self.entity_id} subscribed to event")

--- a/custom_components/monitormysolar/time.py
+++ b/custom_components/monitormysolar/time.py
@@ -4,6 +4,7 @@ import asyncio
 from homeassistant.components.time import TimeEntity
 from homeassistant.core import callback
 from .const import DOMAIN, ENTITIES
+from . import MonitorMySolarEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(entities, True)
 
 class InverterTime(TimeEntity):
-    def __init__(self, entity_info, hass, entry, dongle_id):
+    def __init__(self, entity_info, hass, entry: MonitorMySolarEntry, dongle_id):
         """Initialize the Time entity."""
         _LOGGER.debug(f"Initializing Time entity with info: {entity_info}")
         self.entity_info = entity_info
@@ -38,6 +39,7 @@ class InverterTime(TimeEntity):
         self._manufacturer = entry.data.get("inverter_brand")
         self._last_mqtt_update = None
         self._debounce_task = None
+        self.coordinator = entry.runtime_data
 
     @property
     def name(self):
@@ -80,7 +82,7 @@ class InverterTime(TimeEntity):
 
             _LOGGER.info(f"Setting time value for {self.entity_id} to {value}")
             self.update_state(value)
-            await self.hass.data[DOMAIN]["mqtt_handler"].send_update(
+            await self.coordinator.mqtt_handler.send_update(
                 self._dongle_id.replace("_", "-"),
                 self.entity_info["unique_id"],
                 value.isoformat(),

--- a/custom_components/monitormysolar/time.py
+++ b/custom_components/monitormysolar/time.py
@@ -117,13 +117,9 @@ class InverterTime(TimeEntity):
             if value is not None:
                 self.update_state(value)
 
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        _LOGGER.debug(f"Time {self.entity_id} will be removed from hass")
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_time_updated", self._handle_event)
-
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
         #_LOGGER.debug(f"Time {self.entity_id} added to hass")
-        self.hass.bus.async_listen(f"{DOMAIN}_time_updated", self._handle_event)
-        #_LOGGER.debug(f"Time {self.entity_id} subscribed to event")
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_time_updated", self._handle_event)
+        )

--- a/custom_components/monitormysolar/update.py
+++ b/custom_components/monitormysolar/update.py
@@ -178,14 +178,12 @@ class InverterUpdate(UpdateEntity):
 
     async def async_added_to_hass(self):
         """Subscribe to events when added to hass."""
-        self.hass.bus.async_listen(f"{DOMAIN}_update_version", self._handle_version_update)
+        self.async_on_remove(
+            self.hass.bus.async_listen(f"{DOMAIN}_update_version", self._handle_version_update)
+        )
         # Initial state update
         self._attr_installed_version = self._get_installed_version()
         self.async_write_ha_state()
-
-    async def async_will_remove_from_hass(self):
-        """Unsubscribe from events when removed."""
-        self.hass.bus._async_remove_listener(f"{DOMAIN}_update_version", self._handle_version_update)
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs


### PR DESCRIPTION
When reloading the configuration files in HA, I was seeing this error about `KeyError` in reference to `hass.data[DOMAIN]` references in the [process_message](https://github.com/zakery292/monitormysolar/blob/7d6344654a045de0c50b4ecb578b98a8894c48fd/custom_components/monitormysolar/__init__.py#L166) function. It only occurred when using the "Quick Reload" option in HA. I was working on rotating the log files and when I would reload the config, I was seeing the error in the logs.

Looking around, I came across this [runtime-data](https://developers.home-assistant.io/blog/2024/04/30/store-runtime-data-inside-config-entry/) blog post. SO I tried it in a quick mock and it got rid of the error. I then set out to rework all of the code to use this newer ConfigEntry model.

I renamed the `async_remove_listener` functions to [_async_remove_listener](https://github.com/home-assistant/core/blob/a8713af8b8f226a691754d513fbb6b8906a2228a/homeassistant/core.py#L1723) as I was seeing an error stating the function didn't exist.

Lastly, on these calls, you are passing in `self._handle_event` but that function doesn't exist. I know you are still working on it, but just wanted to pass along.